### PR TITLE
support specialfunctions 2.x

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ Distances = "0.10"
 Entropies = "1"
 Neighborhood = "0.2"
 Reexport = "0.2, 0.3, 1"
-SpecialFunctions = "0.8, 0.9, 0.10, 1.2"
+SpecialFunctions = "0.8, 0.9, 0.10, 1.2, 2"
 StaticArrays = "1"
 julia = "^1.1"
 


### PR DESCRIPTION
The only breaking change in SpecialFunctions 2.0 [was deleting](https://github.com/JuliaMath/SpecialFunctions.jl/pull/297) the `factorial(x::Real) = gamma(x+1)` function, and since you don't use `factorial` this shouldn't affect you.