### PR TITLE
Bug fix in `mutualinfo` for naive neighbor-based estimators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Release v1.7
+
+- Bug fix in `mutualinfo` for naive estimators from Entropies.jl.
+
 ## Release v1.1.4
 
 - Release process updated.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TransferEntropy"
 uuid = "ea221983-52f3-5440-99c7-13ea201cd633"
 repo = "https://github.com/kahaaga/TransferEntropy.jl.git"
-version = "1.6.0"
+version = "1.7.0"
 
 [deps]
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"

--- a/src/mutualinfo/nearestneighbor.jl
+++ b/src/mutualinfo/nearestneighbor.jl
@@ -3,9 +3,11 @@ using Neighborhood
 
 # naive application of estimators in Entropies.jl
 function mutualinfo(x::Vector_or_Dataset, y::Vector_or_Dataset, est::NearestNeighborEntropyEstimator; base = 2)
-    X = genentropy(Dataset(x), est; base = base)
-    Y = genentropy(Dataset(y), est; base = base)
-    XY = genentropy(Dataset(x, y), est; base = base)
+    Hx = genentropy(Dataset(x), est; base = base)
+    Hy = genentropy(Dataset(y), est; base = base)
+    Hxy = genentropy(Dataset(x, y), est; base = base)
+
+    return Hx + Hy - Hxy
 end
 
 abstract type KNNMutualInformationEstimator <: MutualInformationEstimator end


### PR DESCRIPTION
The last line of code in `mutualinfo` for naive neighbor-based estimators was not included. Previously, only the joint entropy was returned.