### PR TITLE
Fix Entropies to v1.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TransferEntropy"
 uuid = "ea221983-52f3-5440-99c7-13ea201cd633"
 repo = "https://github.com/kahaaga/TransferEntropy.jl.git"
-version = "1.9.0"
+version = "1.10.0"
 
 [deps]
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
@@ -19,7 +19,7 @@ TimeseriesSurrogates = "c804724b-8c18-5caa-8579-6025a0767c70"
 DSP = "^0.6.9, ^0.7"
 DelayEmbeddings = "2"
 Distances = "0.10"
-Entropies = "^1.2"
+Entropies = "~1.2"
 Neighborhood = "0.2"
 Reexport = "0.2, 0.3, 1"
 SpecialFunctions = "0.8, 0.9, 0.10, 1.2, 2"


### PR DESCRIPTION
Entropies v2 is about to be released. This PR version-locks Entropies to 1.2 (current release). 